### PR TITLE
Use Riverpod provider in EditShiftDialog

### DIFF
--- a/admin_shift_app/lib/presentation/screens.dart
+++ b/admin_shift_app/lib/presentation/screens.dart
@@ -213,7 +213,6 @@ class _EmployeeDetailScreenState extends ConsumerState<EmployeeDetailScreen> {
   Widget build(BuildContext context) {
     final shiftAsync = ref.watch(currentShiftProvider(widget.employee.id));
     final summaryAsync = ref.watch(monthlySummaryProvider(widget.employee.id));
-    final db = ref.read(dbProvider);
 
     // Проверяем, есть ли активная смена и началась ли она сегодня
     final currentShift = shiftAsync.asData?.value;
@@ -230,7 +229,7 @@ class _EmployeeDetailScreenState extends ConsumerState<EmployeeDetailScreen> {
             PopupMenuButton<String>(
               onSelected: (String result) {
                 if (result == 'editShift') {
-                  _showEditShiftDialog(context, currentShift!, db);
+                  _showEditShiftDialog(context, currentShift!);
                 }
               },
               itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
@@ -316,11 +315,11 @@ class _EmployeeDetailScreenState extends ConsumerState<EmployeeDetailScreen> {
   }
 
   // Новый метод для показа диалога редактирования смены
-  void _showEditShiftDialog(BuildContext context, Shift shift, AppDatabase db) {
+  void _showEditShiftDialog(BuildContext context, Shift shift) {
     showDialog(
       context: context,
       builder: (BuildContext context) {
-        return EditShiftDialog(shift: shift, db: db);
+        return EditShiftDialog(shift: shift);
       },
     );
   }

--- a/admin_shift_app/lib/presentation/widgets/edit_shift_dialog.dart
+++ b/admin_shift_app/lib/presentation/widgets/edit_shift_dialog.dart
@@ -1,19 +1,19 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
-import 'package:drift/drift.dart' as drift;
 
 import '../../data/db/app_database.dart';
+import '../../providers/database_provider.dart';
 
-class EditShiftDialog extends StatefulWidget {
+class EditShiftDialog extends ConsumerStatefulWidget {
   final Shift shift;
-  final AppDatabase db;
-  const EditShiftDialog({super.key, required this.shift, required this.db});
+  const EditShiftDialog({super.key, required this.shift});
 
   @override
-  State<EditShiftDialog> createState() => _EditShiftDialogState();
+  ConsumerState<EditShiftDialog> createState() => _EditShiftDialogState();
 }
 
-class _EditShiftDialogState extends State<EditShiftDialog> {
+class _EditShiftDialogState extends ConsumerState<EditShiftDialog> {
   late final _start = TextEditingController(
       text: DateFormat.Hm().format(widget.shift.start.toLocal()));
   late final _end = TextEditingController(
@@ -33,11 +33,11 @@ class _EditShiftDialogState extends State<EditShiftDialog> {
         TextButton(child: const Text('Отмена'), onPressed: Navigator.of(context).pop),
         FilledButton(
           child: const Text('Сохранить'),
-          onPressed: () {
+          onPressed: () async {
             final day = widget.shift.start.toLocal();
-            final s = _parse(day, _start.text).toUtc();
             final e = _parse(day, _end.text).toUtc();
-            widget.db.endShift(widget.shift.id, e);
+            final db = ref.read(dbProvider);
+            await db.endShift(widget.shift.id, e);
             Navigator.of(context).pop();
           },
         ),


### PR DESCRIPTION
## Summary
- refactor EditShiftDialog into a `ConsumerStatefulWidget`
- get database through `dbProvider` instead of constructor
- adjust EmployeeDetailScreen to match new dialog API

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68446ff823108324b1317aa8ba64f5a8