### PR TITLE
Fix missing sqlite dependency

### DIFF
--- a/admin_shift_app/pubspec.yaml
+++ b/admin_shift_app/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   share_plus: ^11.0.0
   syncfusion_flutter_xlsio: ^29.2.9
   rxdart: ^0.28.0
+  sqlite3_flutter_libs: ^0.5.33
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- include sqlite3_flutter_libs for Drift database

## Testing
- `flutter` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844759f8150832480139cb60e8c8f6b