### PR TITLE
Fix shift updates and add workdays report screens

### DIFF
--- a/admin_shift_app/lib/data/db/app_database.dart
+++ b/admin_shift_app/lib/data/db/app_database.dart
@@ -74,9 +74,15 @@ class AppDatabase extends _$AppDatabase {
 
   // --------------- SHIFTS
   Future<Shift?> currentOpenShift(int empId) =>
-      (select(shifts) 
+      (select(shifts)
             ..where((tbl) => tbl.employeeId.equals(empId) & tbl.end.isNull()))
           .getSingleOrNull();
+
+  /// Stream of open shift to react to DB changes
+  Stream<Shift?> watchCurrentOpenShift(int empId) =>
+      (select(shifts)
+            ..where((tbl) => tbl.employeeId.equals(empId) & tbl.end.isNull()))
+          .watchSingleOrNull();
 
   Future<int> startShift(int empId, DateTime startUtc) =>
       into(shifts).insert(ShiftsCompanion.insert(


### PR DESCRIPTION
## Summary
- stream open shift updates for UI refresh
- report employee workdays with overtime/absence table
- report monthly summary for all employees
- add buttons to open new report screens

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684561b2928c832498fa432123a3a26f